### PR TITLE
Переключение версии SDK на 21.2100 в ветке rc-21.2100

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('pipeline') _
 
-def version = '21.2000'
+def version = '21.2100'
 
 node ('controls') {
     checkout_pipeline("rc-${version}")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "wasaby-cdn",
-   "version": "21.2000.0",
+   "version": "21.2100.0",
    "repository": {
       "type": "git",
       "url": "git@git.sbis.ru:sbis/cdn.git"


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/10416/".